### PR TITLE
tests (as generated by spring initializr) don't run when zuul proxy i…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-eureka</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/test/java/zuulserver/ZuulServerApplicationTests.java
+++ b/src/test/java/zuulserver/ZuulServerApplicationTests.java
@@ -1,0 +1,16 @@
+package zuulserver;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = ZuulServerApplication.class)
+public class ZuulServerApplicationTests {
+
+	@Test
+	public void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
…s enabled:  Sorry, I wasn't sure of a better way to ask about this.  Running 'mvn clean test' or 'mvn clean package' leads to an error in that it can't find ServerProperties when it is autowired in ZuulProxyConfiguration .  This is the test that is generated when spring initializr generates a new project.  Is this something that should be a bug report against spring-cloud-netflix?

Caused by: org.springframework.beans.factory.BeanCreationException: Could not autowire field: private org.springframework.boot.autoconfigure.web.ServerProperties com.bc.discovery.eurekacloud.gateway.CustomZuulProxyConfiguration.server; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type [org.springframework.boot.autoconfigure.web.ServerProperties] found for dependency: expected at least 1 bean which qualifies as autowire candidate for this dependency. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}

